### PR TITLE
Replace bodyguard recall with retaliate charge mechanic                                                                                                                                      

### DIFF
--- a/src/main/java/com/example/examplemod/entity/BodyguardEntity.java
+++ b/src/main/java/com/example/examplemod/entity/BodyguardEntity.java
@@ -36,7 +36,7 @@ import java.util.UUID;
  * Bodyguard entity that protects a Summoner.
  *
  * Fixes included:
- * - Uses Summoner recall token to force ALL guards to return together after Summoner takes 10 hearts of damage.
+ * - Uses Summoner retaliate token to make ALL guards charge the attacker when Summoner takes 10 hearts of player damage.
  *
  * Version: 1.0.0
  * Comments:
@@ -63,6 +63,7 @@ public class BodyguardEntity extends Zombie implements GeoEntity {
     // NBT keys used to persist combat state across world reloads
     private static final String NBT_MODE = "BodyguardMode";
     private static final String NBT_LAST_TARGET = "BodyguardLastTarget";
+    private static final String NBT_RETALIATE_COOLDOWN = "BodyguardRetaliateCooldown";
 
     // Side values stored in NBT (left/right relative to summoner facing direction)
     private static final String SIDE_LEFT = "left";
@@ -73,6 +74,9 @@ public class BodyguardEntity extends Zombie implements GeoEntity {
 
     // Aggro / detection tuning
     private static final double AGGRO_RADIUS = 10.0;
+
+    // Retaliate cooldown (7 seconds at 20 TPS)
+    private static final int RETALIATE_COOLDOWN_TICKS = 140;
 
     // Charge tuning
     private static final int CHARGE_DURATION_TICKS = 60;
@@ -142,11 +146,14 @@ public class BodyguardEntity extends Zombie implements GeoEntity {
     // Attack animation cycling (server-side)
     private int attackAnimTicksLeft = 0;
 
-    // Recall token tracking (server-side)
-    private int lastSeenRecallToken = 0;
+    // Retaliate token tracking (server-side)
+    private int lastSeenRetaliateToken = 0;
 
     // Charge token tracking (server-side)
     private int lastSeenChargeToken = 0;
+
+    // Retaliate cooldown remaining ticks (prevents charge spam after retaliate)
+    private int retaliateCooldownTicksLeft = 0;
 
 
     /**
@@ -416,6 +423,9 @@ public class BodyguardEntity extends Zombie implements GeoEntity {
         if (this.getTarget() != null) {
             tag.putUUID(NBT_LAST_TARGET, this.getTarget().getUUID());
         }
+
+        // Persist retaliate cooldown so it survives reload
+        tag.putInt(NBT_RETALIATE_COOLDOWN, this.retaliateCooldownTicksLeft);
     }
 
     /**
@@ -444,6 +454,11 @@ public class BodyguardEntity extends Zombie implements GeoEntity {
             if (e instanceof Player p) {
                 this.setTarget(p);
             }
+        }
+
+        // Restore retaliate cooldown
+        if (tag.contains(NBT_RETALIATE_COOLDOWN)) {
+            this.retaliateCooldownTicksLeft = tag.getInt(NBT_RETALIATE_COOLDOWN);
         }
     }
 
@@ -492,8 +507,13 @@ public class BodyguardEntity extends Zombie implements GeoEntity {
         // Server-only logic (clients should not simulate AI)
         if (this.level().isClientSide) return;
 
-        // Shared recall event: forces RETURN for all guards at the same time
-        this.tickRecallTokenSync();
+        // Decrement retaliate cooldown each tick
+        if (this.retaliateCooldownTicksLeft > 0) {
+            this.retaliateCooldownTicksLeft--;
+        }
+
+        // Shared retaliate event: charges the attacker when summoner takes enough player damage
+        this.tickRetaliateTokenSync();
 
         // Shared charge event: starts charge for both guards together when Summoner triggers it
         this.tickChargeTokenSync();
@@ -506,41 +526,69 @@ public class BodyguardEntity extends Zombie implements GeoEntity {
 
         // Reacquire target after reload if we are in combat mode
         this.tickReacquireTargetIfNeeded();
+
+        // If in MELEE with no target, fall back to RETURN
+        this.tickMeleeFallbackToReturn();
     }
 
 
     /**
-     * Checks the owning Summoner's recall token and forces RETURN when it changes.
-     *
-     * This ensures:
-     * - Both guards react to the same shared event.
-     * - Guards ignore the player while returning (prevents jitter / indecision movement).
-     * - GUARD mode only resumes after formation is restored.
+     * If in MELEE mode with no target (player died or left), transition to RETURN.
      *
      * Version: 1.0.0
      * Comments:
      */
-    private void tickRecallTokenSync() {
+    private void tickMeleeFallbackToReturn() {
+        if (this.mode != GuardMode.MELEE) return;
+        if (this.getTarget() instanceof Player) return;
+
+        this.clearCombatState();
+        this.setMode(GuardMode.RETURN);
+    }
+
+    /**
+     * Checks the owning Summoner's retaliate token and charges the attacker when it changes.
+     *
+     * This ensures:
+     * - Both guards react to the same shared event.
+     * - Guards charge the player who damaged the summoner past the threshold.
+     * - Guards already mid-charge are NOT interrupted.
+     *
+     * Version: 1.0.0
+     * Comments:
+     */
+    private void tickRetaliateTokenSync() {
 
         SummonerEntity summoner = this.getOwningSummoner();
         if (summoner == null) return;
 
-        int token = summoner.getBodyguardRecallToken();
+        int token = summoner.getBodyguardRetaliateToken();
 
-        // If token changed, summoner triggered a recall event
-        if (token != this.lastSeenRecallToken) {
-            this.lastSeenRecallToken = token;
+        // No new retaliate signal
+        if (token == this.lastSeenRetaliateToken) return;
 
-            // Hard-stop all combat behaviors immediately
-            this.clearCombatState();
+        // Consume token immediately (unlike charge token which defers)
+        this.lastSeenRetaliateToken = token;
 
-            // Enter RETURN mode (ignore player and run back)
-            this.setMode(GuardMode.RETURN);
+        // Must be fully active (not rising)
+        if (!this.isFullyActive()) return;
 
-            // Ensure charge must be re-armed properly after returning
-            this.chargeAvailable = false;
-            this.playerWasInAggroRadius = false;
-        }
+        // Do NOT interrupt an existing charge
+        if (this.getSyncedMode() == GuardMode.CHARGE) return;
+
+        // Must not be on cooldown
+        if (this.retaliateCooldownTicksLeft > 0) return;
+
+        // Resolve the attacker from summoner
+        UUID attackerUUID = summoner.getRetaliateAttackerUUID();
+        if (attackerUUID == null) return;
+        if (!(this.level() instanceof ServerLevel serverLevel)) return;
+        Entity attackerEntity = serverLevel.getEntity(attackerUUID);
+        if (!(attackerEntity instanceof Player attackerPlayer)) return;
+
+        // Clear current combat state and charge the attacker
+        this.clearCombatState();
+        this.startCharge(attackerPlayer);
     }
 
     /**
@@ -564,6 +612,9 @@ public class BodyguardEntity extends Zombie implements GeoEntity {
         if (token == this.lastSeenChargeToken) return;
 
         // ---- Eligibility gates (do NOT consume token unless we pass) ----
+
+        // Do not start a proximity charge while retaliate cooldown is active
+        if (this.retaliateCooldownTicksLeft > 0) return;
 
         // Must be fully active (not rising)
         if (!this.isFullyActive()) return;
@@ -856,6 +907,9 @@ public class BodyguardEntity extends Zombie implements GeoEntity {
         SummonerEntity summoner = this.getOwningSummoner();
         if (summoner == null) return;
 
+        // Do not re-arm while retaliate cooldown is active
+        if (this.retaliateCooldownTicksLeft > 0) return;
+
         // Only re-arm while in GUARD and properly formed beside the summoner
         if (!this.isFullyActive()) return;
         if (this.getSyncedMode() != GuardMode.GUARD) return;
@@ -951,7 +1005,10 @@ public class BodyguardEntity extends Zombie implements GeoEntity {
         // Charge cannot be used again until the guard fully reforms in GUARD mode
         this.chargeAvailable = false;
 
-        // Always go into melee after a charge (unless recall later forces RETURN)
+        // Start retaliate cooldown to prevent charge spam
+        this.retaliateCooldownTicksLeft = RETALIATE_COOLDOWN_TICKS;
+
+        // Always go into melee after a charge (unless retaliate later forces another charge)
         this.setMode(GuardMode.MELEE);
     }
 

--- a/src/main/java/com/example/examplemod/entity/SummonerEntity.java
+++ b/src/main/java/com/example/examplemod/entity/SummonerEntity.java
@@ -44,7 +44,7 @@ import java.util.UUID;
  * - During casting, movement is rooted.
  * - Spawns a summoning circle + mist particles.
  * - Spawns 6 rising minions; 2 are bodyguards and 4 are zombies.
- * - Tracks damage taken centrally and emits a recall token when threshold is reached so all bodyguards return.
+ * - Tracks player damage centrally and emits a retaliate token when threshold is reached so all bodyguards charge the attacker.
  *
  * AI Behavior update:
  * - Summoner behaves like a "stand-still skeleton":
@@ -119,7 +119,7 @@ public class SummonerEntity extends Skeleton implements GeoEntity {
 
 
     // Shared bodyguard recall tuning (10 hearts = 20 damage)
-    private static final float BODYGUARD_RECALL_DAMAGE_THRESHOLD = 20.0F;
+    private static final float BODYGUARD_RETALIATE_DAMAGE_THRESHOLD = 20.0F;
 
     // Aggro radius for starting a synchronized bodyguard charge
     private static final double BODYGUARD_AGGRO_RADIUS = 10.0;
@@ -139,17 +139,20 @@ public class SummonerEntity extends Skeleton implements GeoEntity {
     // UUIDs of currently summoned mobs (used for rising + enabling them)
     private final List<UUID> summonedIds = new ArrayList<>();
 
-    // Centralized damage accumulation for triggering bodyguard recall
-    private float recallDamageAccumulated = 0.0F;
+    // Centralized player damage accumulation for triggering bodyguard retaliate
+    private float retaliateDamageAccumulated = 0.0F;
 
-    // Token increments whenever the recall threshold is reached (guards compare last-seen token)
-    private int bodyguardRecallToken = 0;
+    // Token increments whenever the retaliate threshold is reached (guards compare last-seen token)
+    private int bodyguardRetaliateToken = 0;
 
     // Shared charge token increments whenever a player enters the aggro radius
     private int bodyguardChargeToken = 0;
 
     // Tracks whether a player was previously in the summoner aggro radius
     private boolean playerWasInAggroRadius = false;
+
+    // UUID of the player who last triggered the retaliate threshold
+    private UUID retaliateAttackerUUID = null;
 
     /**
      * Constructs a new SummonerEntity instance.
@@ -372,22 +375,33 @@ public class SummonerEntity extends Skeleton implements GeoEntity {
     }
 
     /**
-     * Returns the current bodyguard recall token.
+     * Returns the current bodyguard retaliate token.
      *
-     * Bodyguards compare this token to their last-seen value; if it changes, they return to guard stance.
+     * Bodyguards compare this token to their last-seen value; if it changes, they charge the attacker.
      *
      * @return int - The current recall token value.
      * Version: 1.0.0
      * Comments:
      */
-    public int getBodyguardRecallToken() {
-        return this.bodyguardRecallToken;
+    public int getBodyguardRetaliateToken() {
+        return this.bodyguardRetaliateToken;
+    }
+
+    /**
+     * Returns the UUID of the player who last triggered the retaliate threshold.
+     *
+     * @return UUID - The attacker's UUID, or null if no attacker recorded.
+     * Version: 1.0.0
+     * Comments:
+     */
+    public UUID getRetaliateAttackerUUID() {
+        return this.retaliateAttackerUUID;
     }
 
     /**
      * Applies damage immunity during the first-ever summon cast.
      *
-     * Also centralizes damage tracking after damage is actually applied so bodyguards can be recalled reliably.
+     * Also centralizes player damage tracking and emits a retaliate token so bodyguards charge the attacker.
      *
      * @param source DamageSource source - The incoming damage source.
      * @param amount float amount - The incoming damage amount.
@@ -407,12 +421,15 @@ public class SummonerEntity extends Skeleton implements GeoEntity {
         boolean applied = super.hurt(source, amount);
         if (!applied) return false;
 
-        // Accumulate damage centrally and emit a recall token when threshold is reached
-        this.recallDamageAccumulated += amount;
+        // Accumulate player damage and emit a retaliate token when threshold is reached
+        if (source.getEntity() instanceof Player attackerPlayer) {
+            this.retaliateDamageAccumulated += amount;
 
-        if (this.recallDamageAccumulated >= BODYGUARD_RECALL_DAMAGE_THRESHOLD) {
-            this.recallDamageAccumulated = 0.0F;
-            this.bodyguardRecallToken++;
+            if (this.retaliateDamageAccumulated >= BODYGUARD_RETALIATE_DAMAGE_THRESHOLD) {
+                this.retaliateAttackerUUID = attackerPlayer.getUUID();
+                this.retaliateDamageAccumulated = 0.0F;
+                this.bodyguardRetaliateToken++;
+            }
         }
 
         return true;


### PR DESCRIPTION
### Summary

  - When the summoner accumulates 10 hearts of player damage, bodyguards now charge the attacker instead of returning to guard formation    
  - Bodyguards in GUARD, MELEE, or RETURN mode interrupt and charge; bodyguards already mid-CHARGE are not interrupted                      
  - 7-second per-bodyguard cooldown prevents charge spam after each charge ends                                                             
  - Bodyguards in MELEE with no target (player died/left) now fall back to RETURN mode                                                      
  - Non-player damage (mobs, environment) no longer triggers the retaliate mechanic                                                         
                                                                                                                                            
###  Testing needed                                                                                                                                                                                                                          
- [x] Spawn summoner, let bodyguards form up, snipe summoner from >10 blocks — bodyguards should charge the player                            
- [x] Verify bodyguards in melee get interrupted into charge on next threshold hit
- [x] Verify bodyguards mid-charge are NOT interrupted
- [x] Verify 7-second cooldown prevents instant re-charge
- [ ] Verify bodyguards return to summoner when target dies/leaves during melee
- [ ] Verify environmental damage (fire, fall) does not trigger retaliate
